### PR TITLE
fix Config's spec.writeConfigMapToRef

### DIFF
--- a/apis/config/v1alpha1/types.go
+++ b/apis/config/v1alpha1/types.go
@@ -52,11 +52,13 @@ type ContentFromSource struct {
 
 // ConfigParameters are the configurable fields of a Config.
 type ConfigParameters struct {
-	Gzip         bool   `json:"gzip,omitempty"`
-	Base64Encode bool   `json:"base64_encode,omitempty"`
-	Boundary     string `json:"boundary,omitempty"`
+	Gzip         bool `json:"gzip,omitempty"`
+	Base64Encode bool `json:"base64_encode,omitempty"`
 
-	Parts []PartSpec `json:"part,omitempty"`
+	// Boundary is the optional mime-boundary. It defaults to a random UUIDv4
+	Boundary string `json:"boundary,omitempty"`
+
+	Parts []PartSpec `json:"parts,omitempty"`
 }
 
 // ConfigObservation are the observable fields of a Config.
@@ -68,7 +70,7 @@ type ConfigObservation struct {
 type ConfigSpec struct {
 	xpv1.ResourceSpec   `json:",inline"`
 	ForProvider         ConfigParameters `json:"forProvider"`
-	WriteCloudInitToRef *xpv1.Reference  `json:"writeCloudInitToRef,omitempty"`
+	WriteCloudInitToRef *DataKeySelector `json:"writeCloudInitToRef,omitempty"`
 }
 
 // A ConfigStatus represents the observed state of a Config.

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/crossplane/crossplane-runtime/apis/common/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -128,7 +127,7 @@ func (in *ConfigSpec) DeepCopyInto(out *ConfigSpec) {
 	in.ForProvider.DeepCopyInto(&out.ForProvider)
 	if in.WriteCloudInitToRef != nil {
 		in, out := &in.WriteCloudInitToRef, &out.WriteCloudInitToRef
-		*out = new(v1.Reference)
+		*out = new(DataKeySelector)
 		**out = **in
 	}
 }

--- a/examples/cloudinit.yaml
+++ b/examples/cloudinit.yaml
@@ -1,0 +1,25 @@
+apiVersion: cloudinit.crossplane.io/v1alpha1
+kind: Config
+metadata:
+  name: cloudinit
+spec:
+  writeCloudInitToRef:
+    name: cloudinit
+  forProvider:
+    boundary: MIMEBOUNDARY
+    part:
+    - content: |
+        #!/bin/sh
+        echo "Hello World, from provider-cloudinit"
+    - content: |
+        #cloud-config
+        users:
+        - default
+        - name: displague
+          gecos: Marques Johansson
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          ssh_authorized_keys:
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDb2bQekw0WkU/ENwSefAqgEM2i3Dw8POxudzP2q5B+jveC8e2ZahaK8nvoqQtZlY8UdpuYnt8wByMzlW+YxG96q8QbP4XDwcbVxfgZapbTezs5lVoQ5hgogmG8Qap1uYqLK6U3EH7wvv0ISj2Hg+liXcZ1DC3D86WLj7viehLiSnNJp9bOIKjMnvm7BS6oao3T/Ui0+bu27oG/gWShnOFWPlkdYeCfJcxoeoVappw2dbqwqUQkz5vuMuFsOJItEia083qNHP9ZV95rgiIap9O0GVo8bEldZWRV4nfLyaGcLK4Z4nrSap9V1Ok6FGk7jT9xLbw/um1A29UxrlANsFer
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4+QpAIHXyFaK2v0ojhMzVsPt07sT+N/jnUarG1iu1gaCZdwxtvIYTMZOhRfSuDCu3iK4PDsF9vT94+A0tLrBQXKo6mG4TqSwYvP2sBc7RSzB+yXU6SK/ofkb6HssGZ24oCflRPj6VTdrDj3+4hR+TidzGx7EhMqenPSO8R5Ce8uE5GPCsEBqYS+CapYd/0tK/Md9vzF68nEYKPtlcvYc62+viFse8D1+sCyuXerMS038q4hGAUMC+WzS6/vD0gl8MNcwShNgaMChLkpifBLNtwMcZhvy8lKz+ssozSr3yjAxS+G7u/Rj5T6+7KGtj22TtJ54oIvEvxRF/536g/xUD
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDR3aVUPvEksR19iW63z5fPGtvIIX841PHDA2IgZiFQeHx3m2QoAmad817pkOqWwVEUp0WC4F1prIpgNH6B/9lGr333kstfJ1C/aJ7BJmfYtJrNMOh11Rmh7SLnrfHS3vRxsU5NjzP9gcsRZG33dokFZwrE7qC1xxUkzsZU/zIFDoCje7/R99WgvBb3Ac2hHRTKDewpt6+oaVVFDui6Vhkt98S6XmgsGAvdLklXhZlh8TXdNV7nXi1g5LymyIfhV+9jZoTRYLd4KGuBZA+7V9rkHxyH6/VphJdxT216XVpW0eZcOOV93OfB2F3YsY6l9dVYEXDExFnOXK4iZPPtY0MupkApTZgWD4fIGXMWnGjfNPVPoylonbGWs662b3zZ+bapcAI8YSP7qSwWJ44XzgJg/sDestpOBmXfIunS3WKtI/VPyta6Etrm/f0qSWXrKy/gXE5u9ovocDPxawQlpwUCVzXELkVxlfyONpP4aP9d/lho6RLeb9g5vA+8bCRj6fs=
+

--- a/examples/providerconfig.yaml
+++ b/examples/providerconfig.yaml
@@ -1,0 +1,5 @@
+apiVersion: cloudinit.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.13.0
 	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
 	github.com/google/go-cmp v0.5.2
-	github.com/google/uuid v1.1.2
+	github.com/google/uuid v1.2.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/pkg/errors v0.9.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,9 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -77,7 +77,7 @@ func RenderCloudinitConfig(d CloudConfiger) (string, error) {
 
 func renderPartsToWriter(mimeBoundary string, parts []PartReader, writer io.Writer) error {
 	if mimeBoundary == "" {
-		# TODO(displague) random uuid will cause infinite resource jitter, lateinitialize boundary in the managed resource instead
+		// TODO(displague) random uuid will cause infinite resource jitter, lateinitialize boundary in the managed resource instead
 		mimeBoundary = uuid.NewString()
 	}
 

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -77,6 +77,7 @@ func RenderCloudinitConfig(d CloudConfiger) (string, error) {
 
 func renderPartsToWriter(mimeBoundary string, parts []PartReader, writer io.Writer) error {
 	if mimeBoundary == "" {
+		# TODO(displague) random uuid will cause infinite resource jitter, lateinitialize boundary in the managed resource instead
 		mimeBoundary = uuid.NewString()
 	}
 

--- a/package/crds/cloudinit.crossplane.io_configs.yaml
+++ b/package/crds/cloudinit.crossplane.io_configs.yaml
@@ -62,10 +62,11 @@ spec:
                   base64_encode:
                     type: boolean
                   boundary:
+                    description: Boundary is the optional mime-boundary. It defaults to a random UUIDv4
                     type: string
                   gzip:
                     type: boolean
-                  part:
+                  parts:
                     items:
                       description: PartSpec defines the Part spec for a Config
                       properties:
@@ -129,13 +130,19 @@ spec:
                 - name
                 type: object
               writeCloudInitToRef:
-                description: A Reference to a named object.
+                description: DataKeySelector defines required spec to access a key of a configmap or secret
                 properties:
-                  name:
-                    description: Name of the referenced object.
+                  key:
                     type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  optional:
+                    type: boolean
                 required:
                 - name
+                - namespace
                 type: object
               writeConnectionSecretToRef:
                 description: WriteConnectionSecretToReference specifies the namespace and name of a Secret to which any connection details for this managed resource should be written. Connection details frequently include the endpoint, username, and password required to connect to the managed resource.


### PR DESCRIPTION
The configmap reference must be namespaced because the managed resource is cluster scoped and has no namespace to reuse.